### PR TITLE
Fix HTTP headers to include headers from Step Scope  (Step.headers → HttpProbe.headers)

### DIFF
--- a/crates/blueprint/src/transpiler/resolve.rs
+++ b/crates/blueprint/src/transpiler/resolve.rs
@@ -201,7 +201,12 @@ fn resolve_step(block: &crate::parser::ast::Block) -> Result<Step, TranspileErro
         }
     }
 
-    let probe = probe.ok_or_else(|| TranspileError::new(format!("step '{name}' has no probe")))?;
+    let mut probe =
+        probe.ok_or_else(|| TranspileError::new(format!("step '{name}' has no probe")))?;
+
+    if let Probe::Http(http_probe) = &mut probe {
+        http_probe.headers = std::mem::take(&mut headers);
+    }
 
     Ok(Step {
         name,
@@ -910,6 +915,36 @@ blueprint "T" {
             }
             other => panic!("expected HttpProbe, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_http_step_headers_are_moved_into_probe_headers() {
+        let bp = transpile_str(
+            r#"
+blueprint "T" {
+    phase "r" {
+        step "root" {
+            probe http GET /
+            headers { User-Agent: test-agent/1.0 }
+            expect { status: 200 }
+        }
+    }
+}
+"#,
+        )
+        .unwrap_or_else(|e| panic!("{e}"));
+
+        let step = &bp.phases[0].steps[0];
+        match &step.probe {
+            Probe::Http(p) => {
+                assert_eq!(
+                    p.headers.get("User-Agent").map(|s| s.as_str()),
+                    Some("test-agent/1.0")
+                );
+            }
+            other => panic!("expected HttpProbe, got {other:?}"),
+        }
+        assert!(step.headers.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Blueprint `.bp` files currently define HTTP headers inside step scope using a `headers { ... }` block.  
However, during transpilation those headers are stored only in `Step.headers`, while `HttpProbe.headers` remains empty.

As a result, HTTP probes execute without the intended request headers.


## Problem

Given a blueprint like:

```bp
blueprint "Test" {
    phase "test" {
        step "user agent" {
            probe http GET /user-agent
            headers { User-Agent: test-agent/1.0 }
            expect {
                status: 200
                body: "test-agent/1.0"
            }
        }
    }
}
```

- `headers` are parsed from step scope (`Step.headers`)
- `probe http ...` resolves to `Probe::Http(HttpProbe { headers: HashMap::new(), ... })`
- executor (`crates/blueprint/src/executor/probes/http.rs`) sends only `probe.headers`

```rust
    let mut builder = match probe.method {
        HttpMethod::GET => client.get(url),
        HttpMethod::POST => client.post(url),
        HttpMethod::PUT => client.put(url),
        HttpMethod::DELETE => client.delete(url),
        HttpMethod::PATCH => client.patch(url),
        HttpMethod::HEAD => client.head(url),
        HttpMethod::OPTIONS => client.request(reqwest::Method::OPTIONS, url),
    };


    for (k, v) in &probe.headers {
        let v = ctx.interpolate(v);
        builder = builder.header(k, v);
    }
```

So requests are sent without step-defined headers.

---

## Root Cause

Scope mismatch between transpiler and executor:

- Transpiler puts headers in `Step.headers`
- Executor reads headers from `HttpProbe.headers`
- No transfer/merge happens between the two

---

## Solution (implemented in this PR)

Adopted **Approach 2**: move headers from step scope to HTTP probe scope during transpilation.

### What changed

In `crates/blueprint/src/transpiler/resolve.rs` (`resolve_step`):

- After resolving the probe, if probe type is HTTP:
  - move `headers` into `HttpProbe.headers` using `std::mem::take`
- Keep non-HTTP probe behavior unchanged

This ensures headers defined in step scope are available where execution expects them.

---

## Alternatives considered

1. **Change blueprint syntax/design** (define headers inline on probe)  
   - Rejected for now: Architectural Decision
   
2. **Move headers during transpilation** ✅  (chosen)

3. **Inject/override headers at execution time from `Step`**  
   - Rejected: executor currently operates on probe-level data; introducing step-to-probe coupling at runtime is not clean/feasible in current structure.


## Tests

Added regression test in `crates/blueprint/src/transpiler/resolve.rs`:

- `test_http_step_headers_are_moved_into_probe_headers`

Validates that:
- step-level `headers { ... }` are present in `Probe::Http.headers`
- `Step.headers` is empty after move (no duplication)