### PR TITLE
Refactor/use bollard for docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.53.1-rc.29.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +680,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -786,6 +847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,12 +865,28 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
 ]
 
 [[package]]
@@ -844,6 +927,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1171,6 +1269,7 @@ name = "luxctl"
 version = "0.13.0"
 dependencies = [
  "async-trait",
+ "bollard",
  "chrono",
  "clap",
  "clap_complete",
@@ -1179,6 +1278,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "flate2",
+ "futures-util",
  "hex",
  "hmac",
  "log",
@@ -1780,6 +1880,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,6 +2214,19 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ nix = { version = "0.29", features = ["signal", "process"] }
 rand = "0.8"
 flate2 = "1"
 tar = "0.4"
+bollard = "0.21.0"
+futures-util = "0.3.32"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/validators/docker/executor.rs
+++ b/src/validators/docker/executor.rs
@@ -307,7 +307,10 @@ impl DockerExecutor {
                 }
             };
 
-        let options = LogsOptionsBuilder::default().stdout(true).build();
+        let options = LogsOptionsBuilder::default()
+            .stderr(true)
+            .stdout(true)
+            .build();
 
         let mut log_stream = self.docker.logs(&id, Some(options));
 

--- a/src/validators/docker/executor.rs
+++ b/src/validators/docker/executor.rs
@@ -107,7 +107,7 @@ impl DockerExecutor {
         })?;
 
         // check docker availability
-        if !self.is_docker_available().await {
+        if !is_docker_available().await {
             return Err("docker not available".to_string());
         }
 
@@ -355,7 +355,6 @@ impl DockerExecutor {
         Ok(())
     }
 
-    /// check if docker is available
     pub async fn is_docker_available(&self) -> bool {
         self.docker.version().await.is_ok()
     }
@@ -402,6 +401,14 @@ impl DockerExecutor {
     }
 }
 
+/// check if docker is available
+pub async fn is_docker_available() -> bool {
+    match Docker::connect_with_local_defaults() {
+        Ok(docker) => docker.version().await.is_ok(),
+        Err(_) => false,
+    }
+}
+
 /// sanitize a string to be valid in a docker image tag
 /// docker tags can only contain lowercase letters, digits, underscores, periods, and hyphens
 fn sanitize_for_docker_tag(s: &str) -> String {
@@ -441,8 +448,7 @@ mod tests {
     #[tokio::test]
     async fn test_is_docker_available_returns_bool() {
         // just verify it doesn't panic
-        let executor = DockerExecutor::new().unwrap();
-        let _ = executor.is_docker_available().await;
+        let _ = is_docker_available().await;
     }
 
     #[tokio::test]

--- a/src/validators/docker/executor.rs
+++ b/src/validators/docker/executor.rs
@@ -2,9 +2,18 @@
 //!
 //! for security, only images registered in the registry module can be executed.
 
+use bollard::body_full;
+use bollard::container::LogOutput;
+use bollard::models::{ContainerCreateBody, HostConfig};
+use bollard::query_parameters::{
+    BuildImageOptionsBuilder, BuilderVersion, CreateContainerOptions, CreateImageOptionsBuilder,
+    KillContainerOptions, LogsOptionsBuilder, RemoveContainerOptionsBuilder, RemoveImageOptions,
+    StartContainerOptions, WaitContainerOptions,
+};
+use bollard::Docker;
+use futures_util::StreamExt;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
-use tokio::process::Command;
 use tokio::time::{timeout, Duration};
 
 use super::registry::{self, ImageSource};
@@ -30,6 +39,7 @@ impl ExecutorResult {
 /// executor for running Dockerfiles
 pub struct DockerExecutor {
     cache_dir: PathBuf,
+    docker: Docker,
 }
 
 impl DockerExecutor {
@@ -42,7 +52,11 @@ impl DockerExecutor {
         std::fs::create_dir_all(&cache_dir)
             .map_err(|e| format!("failed to create cache dir: {}", e))?;
 
-        Ok(Self { cache_dir })
+        // connect to Docker
+        let docker = Docker::connect_with_local_defaults()
+            .map_err(|e| format!("failed to connect to Docker daemon: {}", e))?;
+
+        Ok(Self { cache_dir, docker })
     }
 
     /// download a Dockerfile by name from GitHub
@@ -93,7 +107,7 @@ impl DockerExecutor {
         })?;
 
         // check docker availability
-        if !is_docker_available().await {
+        if !self.is_docker_available().await {
             return Err("docker not available".to_string());
         }
 
@@ -144,12 +158,7 @@ impl DockerExecutor {
             .await;
 
         // cleanup: remove the image
-        let _ = Command::new("docker")
-            .args(["rmi", "-f", &image_tag])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await;
+        let _ = self.remove_image(&image_tag).await;
 
         run_result
     }
@@ -169,20 +178,14 @@ impl DockerExecutor {
 
         // pull the image
         eprintln!("  pulling {} ...", image_url);
-        let pull_result = Command::new("docker")
-            .args(["pull", image_url])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .await
-            .map_err(|e| format!("failed to pull image: {}", e))?;
+        let options = CreateImageOptionsBuilder::default()
+            .from_image(image_url)
+            .build();
 
-        if !pull_result.status.success() {
-            return Ok(ExecutorResult {
-                exit_code: pull_result.status.code().unwrap_or(-1),
-                stdout: String::from_utf8_lossy(&pull_result.stdout).to_string(),
-                stderr: String::from_utf8_lossy(&pull_result.stderr).to_string(),
-            });
+        let mut pull_stream = self.docker.create_image(Some(options), None, None);
+
+        while let Some(item) = pull_stream.next().await {
+            item.map_err(|e| format!("failed to pull image: '{}': {}", image_url, e))?;
         }
 
         // run the container
@@ -197,25 +200,50 @@ impl DockerExecutor {
         context: &str,
         tag: &str,
     ) -> Result<ExecutorResult, String> {
-        let output = Command::new("docker")
-            .args([
-                "build",
-                "-f",
-                dockerfile_path.to_string_lossy().as_ref(),
-                "-t",
-                tag,
-                context,
-            ])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .await
-            .map_err(|e| format!("failed to run docker build: {}", e))?;
+        let tar_gz = self
+            .build_context_tarball(dockerfile_path, context)
+            .map_err(|e| format!("failed to build context tarball: {}", e))?;
+
+        let options = BuildImageOptionsBuilder::default()
+            .dockerfile("Dockerfile")
+            .t(tag)
+            .rm(true)
+            .version(BuilderVersion::BuilderBuildKit)
+            .build();
+
+        let mut build_stream =
+            self.docker
+                .build_image(options, None, Some(body_full(tar_gz.into())));
+
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        let mut had_error = false;
+
+        while let Some(msg) = build_stream.next().await {
+            match msg {
+                Ok(info) => {
+                    if let Some(stream) = info.stream {
+                        stdout.push_str(&stream);
+                    }
+
+                    if let Some(err_detail) = info.error_detail {
+                        if let Some(msg) = err_detail.message {
+                            stderr.push_str(&msg);
+                        }
+                        had_error = true;
+                    }
+                }
+                Err(e) => {
+                    stderr.push_str(&format!("{}\n", e));
+                    had_error = true;
+                }
+            }
+        }
 
         Ok(ExecutorResult {
-            exit_code: output.status.code().unwrap_or(-1),
-            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            exit_code: if had_error { 1 } else { 0 },
+            stdout,
+            stderr,
         })
     }
 
@@ -225,39 +253,149 @@ impl DockerExecutor {
         workspace: &str,
         timeout_secs: Option<u64>,
     ) -> Result<ExecutorResult, String> {
-        let timeout_duration = Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS));
-
-        let result = timeout(
-            timeout_duration,
-            Command::new("docker")
-                .args([
-                    "run",
-                    "--rm",
-                    "--network=host",
-                    "-v",
-                    &format!("{}:/app", workspace),
-                    "-w",
-                    "/app",
-                    image,
-                ])
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output(),
-        )
-        .await;
-
-        match result {
-            Ok(Ok(output)) => Ok(ExecutorResult {
-                exit_code: output.status.code().unwrap_or(-1),
-                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        let secs = timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS);
+        let config = ContainerCreateBody {
+            image: Some(image.to_string()),
+            working_dir: Some("/app".to_string()),
+            host_config: Some(HostConfig {
+                binds: Some(vec![format!("{}:/app", workspace)]),
+                network_mode: Some("host".to_string()),
+                ..Default::default()
             }),
-            Ok(Err(e)) => Err(format!("docker run failed: {}", e)),
-            Err(_) => Err(format!(
-                "container timed out after {}s",
-                timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS)
-            )),
+            ..Default::default()
+        };
+
+        let container = self
+            .docker
+            .create_container(None::<CreateContainerOptions>, config)
+            .await
+            .map_err(|e| format!("failed to create container: {}", e))?;
+
+        let id = container.id;
+
+        if let Err(e) = self
+            .docker
+            .start_container(&id, None::<StartContainerOptions>)
+            .await
+        {
+            let _ = self.cleanup_container(&id).await;
+            return Err(format!("failed to start container: {}", e));
         }
+
+        let wait_stream = self
+            .docker
+            .wait_container(&id, None::<WaitContainerOptions>);
+
+        let exit_code =
+            match timeout(Duration::from_secs(secs), wait_stream.collect::<Vec<_>>()).await {
+                Ok(results) => match results.into_iter().last() {
+                    Some(Ok(res)) => res.status_code as i32,
+                    Some(Err(e)) => {
+                        let _ = self.cleanup_container(&id).await;
+                        return Err(format!("failed to wait for container: {}", e));
+                    }
+                    None => -1,
+                },
+
+                Err(_) => {
+                    let _ = self
+                        .docker
+                        .kill_container(&id, None::<KillContainerOptions>)
+                        .await;
+                    let _ = self.cleanup_container(&id).await;
+                    return Err(format!("container timed out after {} seconds", secs));
+                }
+            };
+
+        let options = LogsOptionsBuilder::default().stdout(true).build();
+
+        let mut log_stream = self.docker.logs(&id, Some(options));
+
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+
+        while let Some(chunk) = log_stream.next().await {
+            match chunk {
+                Ok(LogOutput::StdOut { message }) => {
+                    stdout.push_str(&String::from_utf8_lossy(&message));
+                }
+                Ok(LogOutput::StdErr { message }) => {
+                    stderr.push_str(&String::from_utf8_lossy(&message));
+                }
+                _ => {}
+            }
+        }
+
+        let _ = self.cleanup_container(&id).await;
+
+        Ok(ExecutorResult {
+            exit_code,
+            stdout,
+            stderr,
+        })
+    }
+
+    async fn cleanup_container(&self, id: &str) -> Result<(), String> {
+        let options = RemoveContainerOptionsBuilder::default().force(true).build();
+        self.docker
+            .remove_container(id, Some(options))
+            .await
+            .map_err(|e| format!("failed to remove container '{}': {}", id, e))?;
+        Ok(())
+    }
+
+    async fn remove_image(&self, tag: &str) -> Result<(), String> {
+        self.docker
+            .remove_image(tag, None::<RemoveImageOptions>, None)
+            .await
+            .map_err(|e| format!("failed to remove image '{}': {}", tag, e))?;
+        Ok(())
+    }
+
+    /// check if docker is available
+    pub async fn is_docker_available(&self) -> bool {
+        self.docker.version().await.is_ok()
+    }
+
+    fn build_context_tarball(
+        &self,
+        dockerfile_path: &Path,
+        context: &str,
+    ) -> Result<Vec<u8>, String> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let mut tar = tar::Builder::new(Vec::new());
+
+        tar.append_dir_all("", context)
+            .map_err(|e| format!("failed to create tarball: {}", e))?;
+
+        let dockerfile_content = std::fs::read(dockerfile_path)
+            .map_err(|e| format!("failed to read Dockerfile: {}", e))?;
+
+        let mut header = tar::Header::new_gnu();
+        header
+            .set_path("Dockerfile")
+            .map_err(|e| format!("failed to create tarball: {}", e))?;
+        header.set_size(dockerfile_content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+
+        tar.append(&header, dockerfile_content.as_slice())
+            .map_err(|e| format!("failed to append Dockerfile to tar: {}", e))?;
+
+        let uncompressed = tar
+            .into_inner()
+            .map_err(|e| format!("failed to finalize tar: {}", e))?;
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder
+            .write_all(&uncompressed)
+            .map_err(|e| format!("failed to compress tarball: {}", e))?;
+
+        encoder
+            .finish()
+            .map_err(|e| format!("failed to finish gzip: {}", e))
     }
 }
 
@@ -271,18 +409,6 @@ fn sanitize_for_docker_tag(s: &str) -> String {
             _ => '-',
         })
         .collect()
-}
-
-/// check if docker is available
-pub async fn is_docker_available() -> bool {
-    Command::new("docker")
-        .args(["version", "--format", "{{.Server.Version}}"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .await
-        .map(|s| s.success())
-        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -312,7 +438,8 @@ mod tests {
     #[tokio::test]
     async fn test_is_docker_available_returns_bool() {
         // just verify it doesn't panic
-        let _ = is_docker_available().await;
+        let executor = DockerExecutor::new().unwrap();
+        let _ = executor.is_docker_available().await;
     }
 
     #[tokio::test]

--- a/src/validators/docker/executor.rs
+++ b/src/validators/docker/executor.rs
@@ -64,6 +64,8 @@ impl DockerExecutor {
         let url = format!("{}/{}", DOCKERFILE_BASE_URL, name);
         let cache_path = self.cache_dir.join(name);
 
+        eprintln!("DEBUG fetching: {}", url);
+
         // fetch from GitHub
         let response = reqwest::get(&url)
             .await
@@ -492,5 +494,42 @@ mod tests {
             "api-client-test"
         );
         assert_eq!(sanitize_for_docker_tag("test_image"), "test_image");
+    }
+
+    #[test]
+    fn test_tarball_contains_dockerfile() {
+        use flate2::read::GzDecoder;
+        use std::io::Write;
+
+        let tmp = std::env::temp_dir().join("luxctl_test_ctx");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let dockerfile = tmp.join("Dockerfile.test");
+        let mut f = std::fs::File::create(&dockerfile).unwrap();
+        writeln!(f, "FROM alpine:latest").unwrap();
+        writeln!(f, "RUN echo hello").unwrap();
+
+        let executor = match DockerExecutor::new() {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+
+        let tar_gz = executor
+            .build_context_tarball(&dockerfile, tmp.to_str().unwrap())
+            .expect("tarball should build");
+
+        let decoder = GzDecoder::new(&tar_gz[..]);
+        let mut archive = tar::Archive::new(decoder);
+        let mut found_dockerfile = false;
+        for entry in archive.entries().unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path().unwrap();
+            if path.to_str() == Some("Dockerfile") {
+                found_dockerfile = true;
+            }
+        }
+
+        assert!(found_dockerfile, "tar must contain a Dockerfile entry");
+
+        std::fs::remove_dir_all(&tmp).ok();
     }
 }

--- a/src/validators/docker/executor.rs
+++ b/src/validators/docker/executor.rs
@@ -64,8 +64,6 @@ impl DockerExecutor {
         let url = format!("{}/{}", DOCKERFILE_BASE_URL, name);
         let cache_path = self.cache_dir.join(name);
 
-        eprintln!("DEBUG fetching: {}", url);
-
         // fetch from GitHub
         let response = reqwest::get(&url)
             .await

--- a/src/validators/docker/mod.rs
+++ b/src/validators/docker/mod.rs
@@ -7,6 +7,6 @@ mod executor;
 pub mod registry;
 mod validator;
 
-pub use executor::{DockerExecutor, ExecutorResult};
+pub use executor::{is_docker_available, DockerExecutor, ExecutorResult};
 pub use registry::{lookup as lookup_image, ImageSource, RegisteredImage};
 pub use validator::{DockerValidator, Expectation};

--- a/src/validators/docker/mod.rs
+++ b/src/validators/docker/mod.rs
@@ -7,6 +7,6 @@ mod executor;
 pub mod registry;
 mod validator;
 
-pub use executor::{is_docker_available, DockerExecutor, ExecutorResult};
+pub use executor::{DockerExecutor, ExecutorResult};
 pub use registry::{lookup as lookup_image, ImageSource, RegisteredImage};
 pub use validator::{DockerValidator, Expectation};


### PR DESCRIPTION
Replace shell commands with Bollard API

Migrate the Docker executor from shelling out to the `docker` CLI to
The bollard crate, talking to the daemon directly.

- pull, run, wait, logs, kill, and cleanup now use bollard
- image build uses build_image with a gzip tar context (BuildKit enabled)
- availability check queries the daemon via bollard
- remove unused Stdio and Command imports

Closes #6 
