### PR TITLE
Fix/5 hide email show username

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -126,7 +126,7 @@ async fn check_network(config: &Option<Config>) {
     let client = LighthouseAPIClient::from_config(config);
     match client.me().await {
         Ok(user) => {
-            UI::ok("api", Some(&format!("connected as @{}", user.name)));
+            UI::ok("api", Some(&format!("connected as {}", user.name)));
         }
         Err(e) => {
             UI::error("api", Some(&format!("{}", e)));

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -126,7 +126,7 @@ async fn check_network(config: &Option<Config>) {
     let client = LighthouseAPIClient::from_config(config);
     match client.me().await {
         Ok(user) => {
-            UI::ok("api", Some(&format!("connected as {}", user.email)));
+            UI::ok("api", Some(&format!("connected as @{}", user.name)));
         }
         Err(e) => {
             UI::error("api", Some(&format!("{}", e)));
@@ -229,7 +229,10 @@ fn check_project_state(config: &Option<Config>) {
         if workspace_path.exists() {
             UI::ok("workspace", Some(&project.workspace));
         } else {
-            UI::error("workspace", Some(&format!("{} (not found)", project.workspace)));
+            UI::error(
+                "workspace",
+                Some(&format!("{} (not found)", project.workspace)),
+            );
         }
 
         if let Some(rt) = &project.runtime {


### PR DESCRIPTION
fix(doctor): show <user.name> instead of email address

The `doctor` command's network check printed the authenticated
user's email ("connected as email_address"), leaking it to terminal output,
logs, and screen shares. Replace it with the public <user.name>.

whoami was checked too and does not expose the email.

Closes #5